### PR TITLE
Add optional impostor arg

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -34,7 +34,7 @@ For future reference in this documentation: when referring to 'client' we refer 
  
 All available endpoints you can use.
 
-### client.amongus(username, avatar)
+### client.amongus(username, avatar, impostor)
 ---
 **Premium Endpoint**
 Get a gif from voting someone away as the impostor
@@ -44,6 +44,7 @@ Get a gif from voting someone away as the impostor
 **Parameters:**\
 **- username** *(string)*: The name of the impostor
 **- avatar** *(string)*: The avatar url of the impostor
+**- impostor** *(boolean)* Whether or not the ejected user was an impostor.
 
 **Return type:** [Image](https://github.com/iDutchy/sr_api/blob/master/DOCUMENTATION.md#image "Image object attributes") *(object)*
   

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -34,7 +34,7 @@ For future reference in this documentation: when referring to 'client' we refer 
  
 All available endpoints you can use.
 
-### client.amongus(username, avatar, impostor)
+### client.amongus(username, avatar, impostor=False)
 ---
 **Premium Endpoint**
 Get a gif from voting someone away as the impostor

--- a/sr_api/client.py
+++ b/sr_api/client.py
@@ -44,11 +44,11 @@ class Client:
 
         return str(url)
 
-    def amongus(self, username, avatar):
+    def amongus(self, username, avatar, impostor = False):
         if self.key is None:
             raise PremiumOnly("This endpoint can only be used by premium users.")
 
-        url = self.srapi_url("premium/amongus", {"username": username, "avatar": avatar})
+        url = self.srapi_url("premium/amongus", {"username": username, "avatar": avatar, "impostor": str(impostor).lower()})
         return Image(self._http_client, url)
 
     async def get_image(self, name=None):


### PR DESCRIPTION
The endpoint has an impostor kwarg, and this PR adds support for that into the function. The new impostor arg takes a boolean input and alters the message displayed - "username was not The Impostor" for False, and "username was The Impostor" for True.