### PR TITLE
Petpet endpoint support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -47,7 +47,19 @@ Get a gif from voting someone away as the impostor
 **- impostor** *(boolean)* Whether or not the ejected user was an impostor.
 
 **Return type:** [Image](https://github.com/iDutchy/sr_api/blob/master/DOCUMENTATION.md#image "Image object attributes") *(object)*
-  
+
+### client.petpet(avatar)
+---
+**Premium Endpoint**
+Get a gif of someone or something being petted.
+
+**WARNING:** The Image.url returned by this function will very likely not embed! You will have to use Image.read to get the bytes object and work from there! DO NOT SHARE THE URL EITHER SINCE IT CONTAINS YOUR PREMIUM KEY
+
+**Parameters:**\
+**- avatar** *(string)*: The avatar url of the petted object.
+
+**Return type:** [Image](https://github.com/iDutchy/sr_api/blob/master/DOCUMENTATION.md#image "Image object attributes") *(object)*
+
 ### *await* client.get_image(animal)
 ---
 Get a random animal image.

--- a/sr_api/client.py
+++ b/sr_api/client.py
@@ -50,6 +50,13 @@ class Client:
 
         url = self.srapi_url("premium/amongus", {"username": username, "avatar": avatar, "impostor": str(impostor).lower()})
         return Image(self._http_client, url)
+    
+    def petpet(self, avatar):
+        if self.key is None:
+            raise PremiumOnly("This endpoint can only be used by premium users.")
+
+        url = self.srapi_url("premium/petpet", {"avatar": avatar})
+        return Image(self._http_client, url)
 
     async def get_image(self, name=None):
         options = ("dog", "cat", "panda", "red_panda", "fox", "birb", "koala",


### PR DESCRIPTION
Support for the petpet endpoint. Basically the same code as the amongus endpoint. It takes one parameter - avatar(url) of the object being petted. Documentation updated as well