### PR TITLE
Fix typo in sr_api/quote.py

### DIFF
--- a/sr_api/quote.py
+++ b/sr_api/quote.py
@@ -2,5 +2,5 @@ class Quote:
     __slots__ = ("quote", "character", "anime")
     def __init__(self, data):
         self.quote = data.get('sentence')
-        self.character = data.get('characther')
+        self.character = data.get('character')
         self.anime = data.get('anime')


### PR DESCRIPTION
Fix typo in `sr_api/quote.py` at line 5 where `character` is written as `characther` which cause it to return None always.